### PR TITLE
Redefines atom generator to include the special atoms :nil, :true and :f...

### DIFF
--- a/lib/excheck/generator.ex
+++ b/lib/excheck/generator.ex
@@ -5,7 +5,8 @@ defmodule ExCheck.Generator do
 
   defmacro __using__(_opts \\ []) do
     quote do
-      import :triq_dom, only: :functions  # Import generators defined in :triq.
+      # Import generators defined in :triq minus redefined ones.
+      import :triq_dom, except: [atom: 0], only: :functions
       import ExCheck.Generator
     end
   end
@@ -16,6 +17,15 @@ defmodule ExCheck.Generator do
   defmacro number do
     quote do
       oneof([int(), real()])
+    end
+  end
+
+  @doc """
+  Generates atom, including the special ones :nil, :false and :true.
+  """
+  defmacro atom do
+    quote do
+      oneof([:triq_dom.atom(), oneof([bool(), :nil])])
     end
   end
 end


### PR DESCRIPTION
The atom() generator wasn't generating the atoms :nil, :false and :true that have a special meaning in elixir and should especially be tested.