### PR TITLE
Formatted output + better error loggings from property tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It uses Erlang's [triq](https://github.com/krestenkrab/triq) library for underly
 
 
 ### Installation
-Add ExCheck and triq to your project's dependencies in mix.exs.
+First add ExCheck and triq to your project's dependencies in mix.exs.
 
 ```Elixir
   defp deps do
@@ -14,6 +14,14 @@ Add ExCheck and triq to your project's dependencies in mix.exs.
       {:triq, github: "krestenkrab/triq", only: :test}
     ]
   end
+```
+
+and add the following to test_helpers.exs:
+
+```Elixir
+ExCheck.start
+# ... other helper functions
+ExUnit.start
 ```
 
 ### Usage

--- a/lib/excheck.ex
+++ b/lib/excheck.ex
@@ -22,7 +22,10 @@ defmodule ExCheck do
   end
 
   @doc "Starts the ExCheck application."
-  def start, do: Application.ensure_all_started(:excheck)
+  def start do
+    ExUnit.configure(formatters: [ExCheck.Formatter])
+    Application.ensure_all_started(:excheck)
+  end
 
   @doc "Starts the ExCheck application."
   def start(_app, _type) do

--- a/lib/excheck.ex
+++ b/lib/excheck.ex
@@ -1,4 +1,6 @@
 defmodule ExCheck do
+  use Application
+
   @moduledoc """
   Provides QuickCheck style testing feature.
   add 'use ExCheck' in the ExUnit test files.
@@ -9,7 +11,26 @@ defmodule ExCheck do
       import ExCheck.Predicate
       import ExCheck.Statement
       use ExCheck.Generator
+      use ExUnit.Callbacks
+
+      setup(context) do
+        # Redirect all output first to IOServer process before test starts
+        ExCheck.IOServer.redirect(self)
+        {:ok, context}
+      end
     end
+  end
+
+  @doc "Starts the ExCheck application."
+  def start, do: Application.ensure_all_started(:excheck)
+
+  @doc "Starts the ExCheck application."
+  def start(_app, _type) do
+    import Supervisor.Spec, warn: false
+    children = [
+      worker(ExCheck.IOServer, [])
+    ]
+    Supervisor.start_link(children, strategy: :one_for_one)
   end
 
   @doc """

--- a/lib/excheck/error_agent.ex
+++ b/lib/excheck/error_agent.ex
@@ -1,0 +1,32 @@
+defmodule ExCheck.ErrorAgent do
+  @moduledoc """
+  Agent which stores errors untill all tests are finished.
+  """
+
+  @doc "Start the agent and link it to the calling process."
+  def start_link do
+    Agent.start_link fn -> %{} end
+  end
+
+  @doc "Saves an error message."
+  def add_error(agent, pid, msg) do
+    agent |> Agent.update fn(state) ->
+      error_msgs = Map.get(state, pid, [])
+      Map.put(state, pid, [msg | error_msgs])
+    end
+  end
+
+  @doc "Return all errors stored by this agent."
+  def errors(agent) do
+    agent |> Agent.get fn(state) ->
+      state |> Enum.map fn {_pid, errors} ->
+        Enum.reverse(errors)  # Errors are stored in reverse
+      end
+    end
+  end
+
+  @doc "Stops the agent."
+  def stop(agent) do
+    Agent.stop(agent)
+  end
+end

--- a/lib/excheck/formatter.ex
+++ b/lib/excheck/formatter.ex
@@ -1,0 +1,31 @@
+defmodule ExCheck.Formatter do
+  use GenEvent
+  alias ExUnit.CLIFormatter, as: CF
+
+  @moduledoc """
+  Helper module for properly formatting test output.
+  """
+
+  @doc false
+  def init(opts) do
+    CF.init(opts)
+  end
+
+  @doc false
+  def handle_event(event = {:suite_finished, _run_us, _load_us}, config) do
+    new_cfg = %{config | tests_counter: config.tests_counter + ExCheck.IOServer.total_tests}
+    print_property_test_errors
+    CF.handle_event(event, new_cfg)
+  end
+  def handle_event(event, config) do
+    CF.handle_event(event, config)
+  end
+
+  defp print_property_test_errors do
+    ExCheck.IOServer.errors
+    |> List.flatten
+    |> Enum.map fn({msg, value_list}) ->
+      :io.format(msg, value_list)
+    end
+  end
+end

--- a/lib/excheck/io_server.ex
+++ b/lib/excheck/io_server.ex
@@ -1,15 +1,17 @@
 defmodule ExCheck.IOServer do
   use GenServer
   alias __MODULE__, as: State
+  alias ExCheck.ErrorAgent, as: ErrAgent
 
   @moduledoc """
   Process which manipulates IO output and forwards it to previous group leader.
   """
 
-  defstruct gl: :no_pid,    # Previous group leader process
-            pids: [],       # The pids from which we are redirecting output
-            tests: 0,       # Amount of triq property tests ran
-            enabled: false  # Colors enabled in terminal?
+  defstruct gl: :no_pid,     # Previous group leader process
+            pids: [],        # The pids from which we are redirecting output
+            tests: 0,        # Amount of triq property tests ran
+            enabled: false,  # Colors enabled in terminal?
+            agent: :no_pid
 
   @server __MODULE__
 
@@ -27,19 +29,31 @@ defmodule ExCheck.IOServer do
     @server |> GenServer.call {:redirect, pid}
   end
 
+  @doc "Get the total amount of property tests that ran so far."
+  def total_tests do
+    @server |> GenServer.call :total_tests
+  end
+
+  @doc "Returns all error loggings from property tests"
+  def errors do
+    @server |> GenServer.call :errors
+  end
+
   # Callbacks
 
   @doc false
   def init(:ok) do
+    {:ok, agent} = ErrAgent.start_link
     gl = Process.group_leader        # get previous group leader
-    {:ok, %State{gl: gl, enabled: IO.ANSI.enabled?}}
+    {:ok, %State{gl: gl, enabled: IO.ANSI.enabled?, agent: agent}}
   end
 
   @doc false
-  def terminate(_reason, %State{gl: gl, pids: pids}) do
+  def terminate(_reason, %State{gl: gl, pids: pids, agent: agent}) do
     for pid <- pids do
       Process.group_leader(pid, gl)  # Revert back to old group leader
     end
+    ErrAgent.stop(agent)
     :ok
   end
 
@@ -48,46 +62,78 @@ defmodule ExCheck.IOServer do
     Process.group_leader(pid, self)  # redirect all IO from pid to this process
     {:reply, :ok, %State{state | pids: [pid | pids]}}
   end
+  def handle_call(:total_tests, _from, state = %State{tests: tests}) do
+    {:reply, tests, state}
+  end
+  def handle_call(:errors, _from, state = %State{agent: agent}) do
+    response = ErrAgent.errors(agent)
+    {:reply, response, state}
+  end
 
   @doc false
   def handle_info({:io_request, from, ref, 
                   {:put_chars, :unicode, :io_lib, :format, [msg, value_list]}}, state) do
     # Receive all IO requests here
-    new_state = handle_output(msg, value_list, state)
+    new_state = handle_output(msg, value_list, from, state)
     from |> send {:io_reply, ref, :ok}
     {:noreply, new_state}
   end
   def handle_info({:io_request, from, ref, 
                   {:put_chars, :unicode, msg}}, state) do
     # Receive all IO requests here
-    new_state = handle_output(msg, [], state)
+    new_state = handle_output(msg, [], from, state)
     from |> send {:io_reply, ref, :ok}
     {:noreply, new_state}
   end
+  # TODO need more cases here to handle all forms of IO?
 
   # Helper functions
 
   @doc "Helper function to manipulate output."
-  def handle_output('.', [], state) do
+  def handle_output('.', [], _from, state) do
     '.'
     |> colorize(:green, state.enabled)
     |> write(state)
     state
   end
-  def handle_output('x', [], state) do
+  def handle_output('x', [], _from, state) do
     'x'
     |> colorize(:red, state.enabled)
     |> write(state)
     state
   end
-  def handle_output(msg = '~nRan ~p tests~n', value_list = [amount], state) do
-    :io.format(state.gl, msg, value_list)
-    %State{state | tests: state.tests + amount}# TODO figure out way to print total at end..
-  end 
-  def handle_output(msg, value_list, state) do
+  def handle_output('~nRan ~p tests~n', [amount], _from, state) do
+    %State{state | tests: state.tests + amount}
+  end
+  def handle_output('Testing ~p' ++ _rest, _value_list, _from, state) do
+    # Filter this statement out, output shows up in ExUnit anyway
+    # in case of failure
+    state
+  end
+  def handle_output(msg = ('~nFailed' ++ _rest), value_list, from, state) do
+    add_error_output(state, from, msg, value_list)
+    state
+  end
+  def handle_output('Failed' ++ rest, value_list, from, state) do
+    add_error_output(state, from, '~nFailed' ++ rest, value_list)  # fix formatting..
+    state
+  end
+  def handle_output(msg = 'Simplified' ++ _rest, value_list, from, state) do
+    add_error_output(state, from, msg, value_list)
+    state
+  end
+  def handle_output(msg = '\t~s = ~w~n' ++ _rest, value_list, from, state) do
+    add_error_output(state, from, msg, value_list)
+    state
+  end
+  def handle_output(msg, value_list, _from, state) do
     # Fallback: simply forward messages to old group leader.
     :io.format(state.gl, msg, value_list)
     state
+  end
+
+  defp add_error_output(state, from, msg, value_list) do
+    state.agent |> ErrAgent.add_error(from, {msg, value_list})
   end
 
   defp colorize(msg, color, enabled?) do

--- a/lib/excheck/io_server.ex
+++ b/lib/excheck/io_server.ex
@@ -1,0 +1,102 @@
+defmodule ExCheck.IOServer do
+  use GenServer
+  alias __MODULE__, as: State
+
+  @moduledoc """
+  Process which manipulates IO output and forwards it to previous group leader.
+  """
+
+  defstruct gl: :no_pid,    # Previous group leader process
+            pids: [],       # The pids from which we are redirecting output
+            tests: 0,       # Amount of triq property tests ran
+            enabled: false  # Colors enabled in terminal?
+
+  @server __MODULE__
+
+  # API
+
+  @doc """
+  Starts a new server process, links it to the calling process.
+  """
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok, name: @server)
+  end
+
+  @doc "Redirects IO output from pid to this server."
+  def redirect(pid) do
+    @server |> GenServer.call {:redirect, pid}
+  end
+
+  # Callbacks
+
+  @doc false
+  def init(:ok) do
+    gl = Process.group_leader        # get previous group leader
+    {:ok, %State{gl: gl, enabled: IO.ANSI.enabled?}}
+  end
+
+  @doc false
+  def terminate(_reason, %State{gl: gl, pids: pids}) do
+    for pid <- pids do
+      Process.group_leader(pid, gl)  # Revert back to old group leader
+    end
+    :ok
+  end
+
+  @doc false
+  def handle_call({:redirect, pid}, _from, state = %State{pids: pids}) do
+    Process.group_leader(pid, self)  # redirect all IO from pid to this process
+    {:reply, :ok, %State{state | pids: [pid | pids]}}
+  end
+
+  @doc false
+  def handle_info({:io_request, from, ref, 
+                  {:put_chars, :unicode, :io_lib, :format, [msg, value_list]}}, state) do
+    # Receive all IO requests here
+    new_state = handle_output(msg, value_list, state)
+    from |> send {:io_reply, ref, :ok}
+    {:noreply, new_state}
+  end
+  def handle_info({:io_request, from, ref, 
+                  {:put_chars, :unicode, msg}}, state) do
+    # Receive all IO requests here
+    new_state = handle_output(msg, [], state)
+    from |> send {:io_reply, ref, :ok}
+    {:noreply, new_state}
+  end
+
+  # Helper functions
+
+  @doc "Helper function to manipulate output."
+  def handle_output('.', [], state) do
+    '.'
+    |> colorize(:green, state.enabled)
+    |> write(state)
+    state
+  end
+  def handle_output('x', [], state) do
+    'x'
+    |> colorize(:red, state.enabled)
+    |> write(state)
+    state
+  end
+  def handle_output(msg = '~nRan ~p tests~n', value_list = [amount], state) do
+    :io.format(state.gl, msg, value_list)
+    %State{state | tests: state.tests + amount}# TODO figure out way to print total at end..
+  end 
+  def handle_output(msg, value_list, state) do
+    # Fallback: simply forward messages to old group leader.
+    :io.format(state.gl, msg, value_list)
+    state
+  end
+
+  defp colorize(msg, color, enabled?) do
+    [IO.ANSI.format_fragment(color, enabled?), 
+      msg,
+      IO.ANSI.format_fragment(:reset, enabled?)] |> IO.iodata_to_binary
+  end
+
+  defp write(msg, state) do
+    IO.write state.gl, msg
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule ExCheck.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    []
+    [mod: {ExCheck, []}]
   end
 
   # Returns the list of dependencies in the format:

--- a/test/error_agent_test.exs
+++ b/test/error_agent_test.exs
@@ -1,0 +1,29 @@
+defmodule ExCheck.ErrorAgentTest do
+  use ExUnit.Case, async: false
+  alias ExCheck.ErrorAgent, as: ErrAgent
+
+  test "Starting and stopping agent" do
+    {:ok, agent} = ErrAgent.start_link
+    assert Process.alive?(agent)
+    ErrAgent.stop(agent)
+    refute Process.alive?(agent)
+  end
+
+  test "Adding and returning errors" do
+    me = self
+    other = spawn fn -> :ok end
+    {:ok, agent} = ErrAgent.start_link
+    # Errors could contain anything, using text for simplicity
+    {err1, err2, err3, err4} = {"err1", "err2", "err3", "err4"}
+
+    assert ErrAgent.errors(agent) == []
+    agent |> ErrAgent.add_error(me, err1)
+    assert ErrAgent.errors(agent) == [[err1]]
+    agent |> ErrAgent.add_error(me, err2)
+    assert ErrAgent.errors(agent) == [[err1, err2]]
+    agent |> ErrAgent.add_error(other, err3)
+    assert ErrAgent.errors(agent) == [[err1, err2], [err3]]
+    agent |> ErrAgent.add_error(other, err4)
+    assert ErrAgent.errors(agent) == [[err1, err2], [err3, err4]]
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+ExCheck.start
 ExUnit.start


### PR DESCRIPTION
Fixes #11, currently error loggings are displayed all at once after all tests ran. This could possibly be improved by first monitoring the ExUnit test processes as soon as they emit one of the various "error" messages and then display the errors for that process as soon as the server process notices that a test process goes down.