### PR TITLE
Stick arity/1+ functions in parenthesis in pipes

### DIFF
--- a/lib/excheck/error_agent.ex
+++ b/lib/excheck/error_agent.ex
@@ -10,19 +10,19 @@ defmodule ExCheck.ErrorAgent do
 
   @doc "Saves an error message."
   def add_error(agent, pid, msg) do
-    agent |> Agent.update fn(state) ->
+    agent |> Agent.update(fn(state) ->
       error_msgs = Map.get(state, pid, [])
       Map.put(state, pid, [msg | error_msgs])
-    end
+    end)
   end
 
   @doc "Return all errors stored by this agent."
   def errors(agent) do
-    agent |> Agent.get fn(state) ->
-      state |> Enum.map fn {_pid, errors} ->
+    agent |> Agent.get(fn(state) ->
+      state |> Enum.map(fn {_pid, errors} ->
         Enum.reverse(errors)  # Errors are stored in reverse
-      end
-    end
+      end)
+    end)
   end
 
   @doc "Stops the agent."

--- a/lib/excheck/formatter.ex
+++ b/lib/excheck/formatter.ex
@@ -24,8 +24,8 @@ defmodule ExCheck.Formatter do
   defp print_property_test_errors do
     ExCheck.IOServer.errors
     |> List.flatten
-    |> Enum.map fn({msg, value_list}) ->
+    |> Enum.map(fn({msg, value_list}) ->
       :io.format(msg, value_list)
-    end
+    end)
   end
 end

--- a/lib/excheck/io_server.ex
+++ b/lib/excheck/io_server.ex
@@ -26,17 +26,17 @@ defmodule ExCheck.IOServer do
 
   @doc "Redirects IO output from pid to this server."
   def redirect(pid) do
-    @server |> GenServer.call {:redirect, pid}
+    @server |> GenServer.call({:redirect, pid})
   end
 
   @doc "Get the total amount of property tests that ran so far."
   def total_tests do
-    @server |> GenServer.call :total_tests
+    @server |> GenServer.call(:total_tests)
   end
 
   @doc "Returns all error loggings from property tests"
   def errors do
-    @server |> GenServer.call :errors
+    @server |> GenServer.call(:errors)
   end
 
   # Callbacks
@@ -78,28 +78,28 @@ defmodule ExCheck.IOServer do
                   {:put_chars, _encoding, :io_lib, :format, [msg, value_list]}}, state) do
     # Receive all IO requests here
     new_state = handle_output(msg, value_list, from, state)
-    from |> send {:io_reply, ref, :ok}
+    from |> send({:io_reply, ref, :ok})
     {:noreply, new_state}
   end
   def handle_info({:io_request, from, ref, 
                   {:put_chars, :io_lib, :format, [msg, value_list]}}, state) do
     # Receive all IO requests here
     new_state = handle_output(msg, value_list, from, state)
-    from |> send {:io_reply, ref, :ok}
+    from |> send({:io_reply, ref, :ok})
     {:noreply, new_state}
   end
   def handle_info({:io_request, from, ref, 
                   {:put_chars, _encoding, msg}}, state) do
     # Receive all IO requests here
     new_state = handle_output(msg, [], from, state)
-    from |> send {:io_reply, ref, :ok}
+    from |> send({:io_reply, ref, :ok})
     {:noreply, new_state}
   end
   def handle_info({:io_request, from, ref, 
                   {:put_chars, msg}}, state) do
     # Receive all IO requests here
     new_state = handle_output(msg, [], from, state)
-    from |> send {:io_reply, ref, :ok}
+    from |> send({:io_reply, ref, :ok})
     {:noreply, new_state}
   end
   def handle_info(_msg, state) do


### PR DESCRIPTION
Went through and added parenthesis around function calls where the compiler complains about ambiguity in Elixir 1.2-rc.0.