### PR TITLE
Allow ExUnit tags to set iterations per test

### DIFF
--- a/lib/excheck.ex
+++ b/lib/excheck.ex
@@ -42,8 +42,8 @@ defmodule ExCheck do
   Check the property defined in the specified target (module or method).
   If the module name is specified, check all the methods prefixed with 'prop_'.
   """
-  def check(target) do
-    case :triq.check(target, @iterations) do
+  def check(target, iterations \\ :nil) do
+    case :triq.check(target, iterations || @iterations) do
       true ->
         true
       false ->

--- a/lib/excheck/statement.ex
+++ b/lib/excheck/statement.ex
@@ -11,8 +11,8 @@ defmodule ExCheck.Statement do
     contents = Macro.escape(contents, unquote: true)
     quote bind_quoted: binding do
       def unquote(:"prop_#{message}")(), do: unquote(contents)
-      test :"#{message}_property" do
-        assert ExCheck.check(unquote(:"prop_#{message}")())
+      test :"#{message}_property", context do
+        assert ExCheck.check(unquote(:"prop_#{message}")(), context[:iterations])
       end
     end
   end
@@ -26,7 +26,7 @@ defmodule ExCheck.Statement do
     quote bind_quoted: binding do
       def unquote(:"prop_#{message}")(unquote(var)), do: unquote(contents)
       test :"#{message}_property", var do
-        assert ExCheck.check(unquote(:"prop_#{message}")(var))
+        assert ExCheck.check(unquote(:"prop_#{message}")(var), var[:iterations])
       end
     end
   end


### PR DESCRIPTION
This is a minor change to handle a major annoyance; this PR allows you to specify the number of iterations for a test via ExUnit's tag system.

For example:

```elixir
@tag iterations: 35
property "test some property" do
  for_all v in int do
    is_integer(v)
  end
end
```

As with ExUnit, `@tag` works per test and `@moduletag` works per module. When no tag is found, ExCheck defaults to the number of iterations defined in the config as per current behavior.