### PR TITLE
Resolve config at runtime rather than compile time

### DIFF
--- a/lib/excheck.ex
+++ b/lib/excheck.ex
@@ -6,8 +6,6 @@ defmodule ExCheck do
   add 'use ExCheck' in the ExUnit test files.
   """
 
-  @iterations Application.get_env(:excheck, :number_iterations, 100)
-
   defmacro __using__(_opts \\ []) do
     quote do
       import ExCheck.Predicate
@@ -43,7 +41,8 @@ defmodule ExCheck do
   If the module name is specified, check all the methods prefixed with 'prop_'.
   """
   def check(target, iterations \\ :nil) do
-    case :triq.check(target, iterations || @iterations) do
+    default_iterations = Application.get_env(:excheck, :number_iterations, 100)
+    case :triq.check(target, iterations || default_iterations) do
       true ->
         true
       false ->

--- a/lib/excheck/statement.ex
+++ b/lib/excheck/statement.ex
@@ -2,7 +2,6 @@ defmodule ExCheck.Statement do
   @moduledoc """
   Provides macros for test statements.
   """
-  @iteration_count Application.get_env(:excheck, :number_iterations, 100)
 
   @doc """
   Generate property method and ExUnit tests.
@@ -36,7 +35,8 @@ defmodule ExCheck.Statement do
   It corresonds to triq#check_forall method.
   """
   def verify_property({:"prop:forall", domain, _syntax, fun, _body}) do
-    verify_property(0, @iteration_count, domain, fun, 0)
+    iterations = Application.get_env(:excheck, :number_iterations, 100)
+    verify_property(0, iterations, domain, fun, 0)
   end
 
   defp verify_property(n, n, _domain, _fun, _count), do: true


### PR DESCRIPTION
Use of module attributes means that these values are resolved at compile
time, and thus do not change when projects using this lib change their
mix config. Unless they wipe the library and manually compile them that
is.

I've moved them to be resolved at compile time, which fixes this
problem. Mix conf is stored in an ETS table, so it's still v fast :)