### PR TITLE
Minor Improvement in the installation instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ It uses Erlang's [triq](https://github.com/krestenkrab/triq) library for underly
 
 
 ### Installation
-You may need to install erlang erlang-eunit rebar
 
 First add ExCheck and triq to your project's dependencies in mix.exs.
 
@@ -17,6 +16,7 @@ First add ExCheck and triq to your project's dependencies in mix.exs.
     ]
   end
 ```
+You need to have erlang-eunit installed in order to build triq.
 
 and add the following to test_helper.exs:
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ It uses Erlang's [triq](https://github.com/krestenkrab/triq) library for underly
 
 
 ### Installation
+You may need to install erlang erlang-eunit rebar
+
 First add ExCheck and triq to your project's dependencies in mix.exs.
 
 ```Elixir


### PR DESCRIPTION
The triq library needs the **erlang eunit** library in order to work.
When running the property based tests the erlang compiler will fail with the following error **undefined parse transform 'eunit_autoexport'** if erlang eunit is not installed.

In the README.md, it has been made explicit that erlang-eunit is needed in order to build the triq dependency.