### PR TITLE
Require Elixir 1.3 for v0.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExCheck.Mixfile do
   def project do
     [ app: :excheck,
       version: "0.4.0",
-      elixir: "~> 1.0",
+      elixir: "~> 1.3",
       deps: deps,
       description: description,
       package: package,


### PR DESCRIPTION
18e7b99 isn't backwards compatible with Elixir versions < 1.3.