### PR TITLE
Update formatter to handle older Elixir versions

### DIFF
--- a/lib/excheck/formatter.ex
+++ b/lib/excheck/formatter.ex
@@ -13,8 +13,13 @@ defmodule ExCheck.Formatter do
 
   @doc false
   def handle_event(event = {:suite_finished, _run_us, _load_us}, config) do
-    updated_test_count = config.tests_counter.test + ExCheck.IOServer.total_tests
-    new_cfg = %{config | tests_counter: %{test: updated_test_count}}
+    updated_test_count =
+      if is_map(config.tests_counter) do
+        %{test: config.tests_counter.test + ExCheck.IOServer.total_tests}
+      else
+        config.tests_counter + ExCheck.IOServer.total_tests
+      end
+    new_cfg = %{config | tests_counter: updated_test_count}
     print_property_test_errors
     CF.handle_event(event, new_cfg)
   end

--- a/lib/excheck/formatter.ex
+++ b/lib/excheck/formatter.ex
@@ -13,13 +13,8 @@ defmodule ExCheck.Formatter do
 
   @doc false
   def handle_event(event = {:suite_finished, _run_us, _load_us}, config) do
-    updated_test_count =
-      if is_map(config.tests_counter) do
-        %{test: config.tests_counter.test + ExCheck.IOServer.total_tests}
-      else
-        config.tests_counter + ExCheck.IOServer.total_tests
-      end
-    new_cfg = %{config | tests_counter: updated_test_count}
+    updated_tests_count = update_tests_counter(config.tests_counter)
+    new_cfg = %{config | tests_counter: updated_tests_count}
     print_property_test_errors
     CF.handle_event(event, new_cfg)
   end
@@ -33,5 +28,12 @@ defmodule ExCheck.Formatter do
     |> Enum.map(fn({msg, value_list}) ->
       :io.format(msg, value_list)
     end)
+  end
+
+  defp update_tests_counter(tests_counter) when is_integer(tests_counter) do
+    tests_counter + ExCheck.IOServer.total_tests
+  end
+  defp update_tests_counter(tests_counter) when is_map(tests_counter) do
+    %{tests_counter | test: tests_counter.test + ExCheck.IOServer.total_tests}
   end
 end


### PR DESCRIPTION
18e7b99 updated the formatter to handle ExUnit's `tests_counter` change
from an integer to a map in
https://github.com/elixir-lang/elixir/commit/c4d6be64581b9587dafe4ea5aef346e1684461da#diff-0ed5c47cc55f463c3af34af96d1fef62L18
in a way that wasn't backwards compatible with older Elixir versions.

This updates the formatter to handle older Elixir versions by checking
whether `tests_counter` is a map and updating it accordingly.