### PR TITLE
Add ex_doc for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 erl_crash.dump
 *.ez
 _build
+doc/

--- a/lib/excheck/sample.ex
+++ b/lib/excheck/sample.ex
@@ -15,12 +15,14 @@ defmodule ExCheck.Sample do
   end
 
 
+  @doc false
   def prop_concat_list do
     for_all({xs, ys}, {list(int), list(int)}) do
       Enum.count(concat(xs, ys)) == Enum.count(xs) + Enum.count(ys)
     end
   end
 
+  @doc false
   def prop_push_list do
     for_all({x, y}, {int, list(int)}) do
       result = push(x, y)

--- a/mix.exs
+++ b/mix.exs
@@ -3,6 +3,9 @@ defmodule ExCheck.Mixfile do
 
   def project do
     [ app: :excheck,
+      name: "ExCheck",
+      source_url: "https://github.com/parroty/ExCheck.git",
+      homepage_url: "https://github.com/parroty/ExCheck.git",
       version: "0.5.0",
       elixir: "~> 1.0",
       deps: deps,
@@ -23,7 +26,8 @@ defmodule ExCheck.Mixfile do
   def deps do
     [
       {:excoveralls, "~> 0.5", only: :test},
-      {:triq, github: "triqng/triq"}
+      {:triq, github: "triqng/triq"},
+      {:ex_doc, "~> 0.12", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "exactor": {:git, "git://github.com/sasa1977/exactor.git", "f7f6bae7fead5e0e5525581d44311f803169fa4e", []},
   "excoveralls": {:hex, :excoveralls, "0.5.5", "d97b6fc7aa59c5f04f2fa7ec40fc0b7555ceea2a5f7e7c442aad98ddd7f79002", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},


### PR DESCRIPTION
Adds generation of docs to ExCheck. Resolves #24.
Probably best to release this as 0.5.1 so docs are also published to hex.