### PR TITLE
Fix reporting failed cases

### DIFF
--- a/lib/excheck/error_agent.ex
+++ b/lib/excheck/error_agent.ex
@@ -3,9 +3,11 @@ defmodule ExCheck.ErrorAgent do
   Agent which stores errors untill all tests are finished.
   """
 
+  @initial_state %{}
+
   @doc "Start the agent and link it to the calling process."
   def start_link do
-    Agent.start_link fn -> %{} end
+    Agent.start_link fn -> @initial_state end
   end
 
   @doc "Saves an error message."
@@ -17,17 +19,15 @@ defmodule ExCheck.ErrorAgent do
   end
 
   @doc "Return all errors stored by this agent."
-  def errors(agent) do
-    agent |> Agent.get(fn(state) ->
-      state |> Enum.map(fn {_pid, errors} ->
-        Enum.reverse(errors)  # Errors are stored in reverse
-      end)
+  def flush_errors(agent) do
+    agent |> Agent.get_and_update(fn(state) ->
+      {
+        state |> Enum.map(fn {_pid, errors} ->
+          Enum.reverse(errors)  # Errors are stored in reverse
+        end),
+        @initial_state
+      }
     end)
-  end
-
-  @doc "Clears all errors stored by this agent."
-  def clear_errors(agent) do
-    agent |> Agent.update(fn(_) -> %{} end)
   end
 
   @doc "Stops the agent."

--- a/lib/excheck/formatter.ex
+++ b/lib/excheck/formatter.ex
@@ -50,7 +50,7 @@ defmodule ExCheck.Formatter do
   end
 
   defp print_property_test_errors do
-    ExCheck.IOServer.errors
+    ExCheck.IOServer.flush_errors
     |> List.flatten
     |> Enum.map(fn({msg, value_list}) ->
       :io.format(msg, value_list)

--- a/lib/excheck/io_server.ex
+++ b/lib/excheck/io_server.ex
@@ -39,9 +39,9 @@ defmodule ExCheck.IOServer do
     @server |> GenServer.call(:reset_test_count)
   end
 
-  @doc "Returns all error loggings from property tests"
-  def errors do
-    @server |> GenServer.call(:errors)
+  @doc "Returns and clears all error loggings from property tests"
+  def flush_errors do
+    @server |> GenServer.call(:flush_errors)
   end
 
   # Callbacks
@@ -71,11 +71,10 @@ defmodule ExCheck.IOServer do
     {:reply, tests, state}
   end
   def handle_call(:reset_test_count, _from, state = %State{agent: agent}) do
-    agent |> ErrAgent.clear_errors
     {:reply, :ok, %State{state | tests: 0}}
   end
-  def handle_call(:errors, _from, state = %State{agent: agent}) do
-    response = ErrAgent.errors(agent)
+  def handle_call(:flush_errors, _from, state = %State{agent: agent}) do
+    response = ErrAgent.flush_errors(agent)
     {:reply, response, state}
   end
   def handle_call(_msg, _from, state) do

--- a/test/error_agent_test.exs
+++ b/test/error_agent_test.exs
@@ -9,21 +9,23 @@ defmodule ExCheck.ErrorAgentTest do
     refute Process.alive?(agent)
   end
 
-  test "Adding and returning errors" do
+  test "Adding and flushing errors" do
     me = self()
     other = spawn fn -> :ok end
     {:ok, agent} = ErrAgent.start_link
     # Errors could contain anything, using text for simplicity
     {err1, err2, err3, err4} = {"err1", "err2", "err3", "err4"}
 
-    assert ErrAgent.errors(agent) == []
+    assert ErrAgent.flush_errors(agent) == []
     agent |> ErrAgent.add_error(me, err1)
-    assert ErrAgent.errors(agent) == [[err1]]
+    assert ErrAgent.flush_errors(agent) == [[err1]]
+    assert ErrAgent.flush_errors(agent) == []
+    agent |> ErrAgent.add_error(me, err1)
     agent |> ErrAgent.add_error(me, err2)
-    assert ErrAgent.errors(agent) == [[err1, err2]]
+    assert ErrAgent.flush_errors(agent) == [[err1, err2]]
+    agent |> ErrAgent.add_error(me, err1)
     agent |> ErrAgent.add_error(other, err3)
-    assert ErrAgent.errors(agent) == [[err1, err2], [err3]]
     agent |> ErrAgent.add_error(other, err4)
-    assert ErrAgent.errors(agent) == [[err1, err2], [err3, err4]]
+    assert ErrAgent.flush_errors(agent) == [[err1], [err3, err4]]
   end
 end


### PR DESCRIPTION
Since 0.5.2 the data for failed cases is not shown in the test output.
This fixes it while also making the failed cases display only once in
umbrella projects. It seems `:reset_test_count` is called before
generating the output, so cleaning `ErrAgent` there leads to surpressing
the output.

The approach taken here is to make `ErrAgent` clean itself
when you read from it. That's fine because it's only ever read once (per
project in case of umbrella) to generate the output.