### PR TITLE
Remove outdated comment in README about number_iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ use Mix.Config
 # And then in this file (or different amount in each config file):
 config :excheck, :number_iterations, 200
 ```
-**Note:** This setting is not effective for `ExCheck.check(module_name)` at the moment (refer to [#13](https://github.com/parroty/excheck/pull/13)).
 
 ### Usage
 The following is an testing example. `ExCheck.SampleTest` is the testing code for `ExCheck.Sample`.


### PR DESCRIPTION
The limitation in specifying a number of tests to run with`ExCheck.check(module_name)` seems to have been fixed, so let's remove the comment referring to it to minimise possible confusion.